### PR TITLE
Turn alertify into dedicated Go package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,7 @@ _testmain.go
 # ignore go build and test outputs
 coverage.txt
 coverage.out
-alertify
 
 # ignore HTML files produced by gopfield
 *.html
 vendor/
-.local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - "1.8"
   - "1.9"
   - "1.10"
 
@@ -14,7 +13,7 @@ install:
 script:
   - make dep
   - make check
-  - make build
+  - make all
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,17 @@ CLEAN=go clean
 INSTALL=go install
 BUILDPATH=./_build
 PACKAGES=$(shell go list ./... |grep -v vendor/)
+EXAMPLES=$(shell find examples/* -maxdepth 0 -type d -exec basename {} \;)
+
+examples: builddir
+	for example in $(EXAMPLES); do \
+		go build -o "$(BUILDPATH)/$$example" "examples/$$example/$$example.go"; \
+	done
+
+all: examples
+
+slackertify: builddir
+	go build -o "$(BUILDPATH)/slackertify" "examples/slackertify/slackertify.go"
 
 builddir:
 	mkdir -p $(BUILDPATH)
@@ -22,7 +33,7 @@ dep: godep
 
 check:
 	for pkg in ${PACKAGES}; do \
-		go vet $$pkg || exit ; \
+		go vet -composites=false $$pkg || exit ; \
 		golint $$pkg || exit ; \
 	done
 
@@ -31,7 +42,4 @@ test:
 		go test -coverprofile="../../../$$pkg/coverage.txt" -covermode=atomic $$pkg || exit; \
 	done
 
-build: builddir
-	go build -ldflags="-s -w" -o "$(BUILDPATH)/alertify"
-
-.PHONY: clean
+.PHONY: clean examples

--- a/README.md
+++ b/README.md
@@ -1,102 +1,163 @@
 # alertify
 
 [![GoDoc](https://godoc.org/github.com/milosgajdos83/alertify?status.svg)](https://godoc.org/github.com/milosgajdos83/alertify)
+[![Go Report Card](https://goreportcard.com/badge/milosgajdos83/alertify)](https://goreportcard.com/report/github.com/milosgajdos83/alertify)
 [![License](https://img.shields.io/:license-apache-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Travis CI](https://travis-ci.org/milosgajdos83/alertify.svg?branch=master)](https://travis-ci.org/milosgajdos83/alertify)
 
-**THIS IS JUST A POC WRITEN FOR LOLZ**
+`alertify` is a simple `Go` package which allows to play a song on a [Spotify](https://www.spotify.com/uk/) device upon receiving alert message from a preconfigured source or via HTTP API request.
 
-`alertify` is a simple service which listens to Slack messages in a provided Slack channel and plays a song on Spotify when a requested message pattern is matched
+The original goal of the project was to play a Spotify song when a critical infrastructure alert is detected in a dedicated Slack channel. The project has since evolved beyond this goal and now allows to plug in different monitoring sources.
 
-# Prerequisities
+# Prerequisites
 
-`alertify` uses both Spotify and Slack API therefore there is a couple of prerequisities that need to be satisfied before you can run it.
+`alertify` uses Spotify API therefore there is a couple of prerequisites which need to be satisfied before you can use it.
 
 ## Spotify API access
 
-`alertify` uses [Spotify Connect Web API](https://beta.developer.spotify.com/documentation/web-api/guides/using-connect-web-api/) to play a preconfigured song on a Spotify device. Spotify Connect API uses OAuth to authenticate your application and providing it with required API access scopes.
+Before you use `alertify` package you need to register your application on [Spotify developer portal](https://beta.developer.spotify.com/dashboard/applications). Retrieve the `Client ID` and `Client Secret` API keys and store them in a secure location.
 
-Before you run `alertify` you need to register it as an app on [Spotify developer portal](https://beta.developer.spotify.com/dashboard/applications) first. Retrieve the `Client ID` and `Client Secret` API keys and store them safely. In the app settings you need to specify **Redirect URIs** where `alertify` redirects you after the Spotify authentication failure or success.
+`alertify` uses [Spotify Connect Web API](https://beta.developer.spotify.com/documentation/web-api/guides/using-connect-web-api/) to play a song on a Spotify device. Spotify Connect API uses `OAuth` to grant the permissions to your application with the following Spotify API access scopes.
+* [user-read-currently-playing](https://beta.developer.spotify.com/documentation/general/guides/scopes/#user-read-currently-playing)
+* [user-modify-playback-state](https://beta.developer.spotify.com/documentation/general/guides/scopes/#user-modify-playback-state)
+* [user-read-playback-state](https://beta.developer.spotify.com/documentation/general/guides/scopes/#user-read-playback-state)
 
-## Slack API access
+## Spotify application settings
 
-Retrieve Slack API keys via Slack dashboard. `alertify` uses the old bot API keys which provide full access to all channels: this might change in the future into latest API which provides OAuth authentication with finegrained API access permissions.
+Once your application has been registered, you need to visit your application settings in the [developer portal](https://beta.developer.spotify.com/dashboard/applications) and specify **Redirect URIs** where the `alertify` Spotify API client will redirect you after the API authentication failure or success.
 
-# Get started
+# Design notes
 
-Export your Spotify ID and secret keys via environment variables:
+At the core of the package is `alertify.Bot` object, which is responsible for playing the songs on the preconfigured Spotify device. Besides the ability to play the Spotify songs, `alertify.Bot` also provides a simple HTTP API service, alas at this point the API service does not provide any authentication so be careful if you use this project on publicly accessible network: luckily the API service can be bound to a local `unix` socket, so you might want to use that option.
+
+`alertify.Bot` is intended to run in a dedicated `goroutine` and when run on its own it does nothing unless being explicitly requested to play a song via its HTTP API. The API also provides an endpoint which allows to pause the song playback.
+
+Things get more interesting when you register some alert "monitors" with the `alertify.Bot`. The monitors are objects which satisfy `alertify.Monitor` interface and which can communicate with `alertify.Bot` by sending it `alertify.Msg` objects over the predefined `Go` channel. Please see the [Godoc](https://godoc.org/github.com/milosgajdos83/alertify) for implementation details.
+
+If I have more time I'll move the local in-process communication from `Go` channels to `protobufs` or provide `protobufs` communication interface as well,  but at this point I couldnt be bothered as it's just a fun side project and `Go channel` communication is easy to implement without any extra dependencies.
+
+## Simple example
+
+The code snippet below illustrates how you would normally use the `alertify` package. For a more elaborate example please read below about the `slackertify` example or see the full source code in the project examples directory.
+
+```Go
+        // create bot
+        bot, err := alertify.NewBot(botConfig)
+        if err != nil {
+                log.Printf("Error creating bot: %v", err)
+                os.Exit(1)
+        }
+
+        // Create Slack monitor
+        slack, err := monitor.NewSlackMonitor(slackConfig)
+        if err != nil {
+                log.Printf("Error creating slack monitor: %s", err)
+                os.Exit(1)
+        }
+
+        // register slack monitor
+        if err := bot.RegisterMonitor(slack); err != nil {
+                log.Printf("Error registering %s: %s", slack, err)
+                os.Exit(1)
+        }
+
+        log.Fatal(bot.ListenAndAlert())
+```
+
+# slackertify
+
+The project provides a slightly more elaborate example about how to use `alertify` to monitor message in a predefined [Slack](https://slack.com/) channel for a particular message pattern. It uses Slack RTM (Real Time Message) API, so beside the Spotify API keys described earlier in this README, you will need to register the example on the Slack workspace portal to retrieve Slack API keys.
+
+## Spotify API keys
+
+Provided you have registered `slackertify` via the earlier described Spotify API developer portal, you need to export your Spotify ID and secret keys via the following environment variables:
 
 ```
 export SPOTIFY_ID="xxx"
 export SPOTIFY_SECRET="xxx"
 ```
 
-Export your Slack API key via environment variable:
+## Slack API keys
+
+Similarly, once you've registered `slackertify` on Slack, export your Slack API keys via the following environment variable:
 
 ```
 export SLACK_API_KEY="xxx"
 ```
 
-`go get` the project and ensure its dependencies are met:
+## Get started
+
+`go get` the project and ensure its dependencies are vendored:
 
 ```
-$ go get github.com/milosgajdos83/alertify
+$ go get -u github.com/milosgajdos83/alertify
 $ cd $GOPATH/src/github.com/milosgajdos83/alertify && make dep
 ```
 
-Build the binary:
+Build the `slackertify` binary:
 
 ```
-$ make build
+$ make slackertify
+mkdir -p ./_build
+go build -o "./_build/slackertify" "examples/slackertify/slackertify.go"
 ```
 
-Run the service:
+You can also build all examples as follows:
 
 ```
-$ ./_build/alertify -help
-Usage of ./_build/alertify:
-  -alert-bot string
-    	Slack bot which sends alerts (default "production")
-  -alert-channel string
-    	Slack channel that receives alerts (default "devops-production")
-  -alert-msg string
-    	Slack message regexp we are matching the alert messages on (default "alert")
+$ make all
+mkdir -p ./_build
+for example in slackertify; do \
+		go build -o "./_build/$example" "examples/$example/$example.go"; \
+	done
+```
+
+Display the help:
+
+```
+$ ./_build/slackertify -help
+Usage of ./_build/slackertify:
   -device-id string
     	Spotify device ID as recognised by Spotify API
   -device-name string
     	Spotify device name as recognised by Spotify API
   -redirect-uri string
-    	OAuth app redirect URI set in Spotify API console (default "http://localhost:8080/callback")
+    	Spotify API redirect URI (default "http://localhost:8080/callback")
+  -slack-channel string
+    	Slack channel that receives alerts (default "devops-production")
+  -slack-msg string
+    	A regexp we are matching the slack messages on (default "alert")
+  -slack-user string
+    	Slack username whose message we alert on (default "production")
   -song-uri string
     	Spotify song URI (default "spotify:track:2xYlyywNgefLCRDG8hlxZq")
 ```
 
-# Running alertify
+## Running slackertify
 
-`alertify` will prompt you to authenticate with Spotify API on start requesting API access permissions defined by the following scopes:
-* [user-read-currently-playing](https://beta.developer.spotify.com/documentation/general/guides/scopes/#user-read-currently-playing)
-* [user-modify-playback-state](https://beta.developer.spotify.com/documentation/general/guides/scopes/#user-modify-playback-state)
-* [user-read-playback-state](https://beta.developer.spotify.com/documentation/general/guides/scopes/#user-read-playback-state)
+You can run the `slackertify` like this:
 
-Once you've authenticated and granted `alertify` required permissions you are all set to be notified by a song played on a specified Spotify device.
+```
+$ ./_build/slackertify -slack-channel "test-bot" -slack-msg "alert" -slack-user "gyre"
+```
+
+On the start you will be prompted to visit Spotify authentication URL where you'll grant the access to the earlier described Spotify API scopes. Once you have successfully authentication you are ready to start alerting \o/:
+
+```
+[ slackertify ] Registering HTTP route -> Method: POST, Path: /alert/play
+[ slackertify ] Registering HTTP route -> Method: POST, Path: /alert/silence
+[ slackertify ] Starting bot message listener
+[ slackertify ] Starting Slack Monitor
+[ slackertify ] Starting HTTP API service
+```
 
 ## Spotify devices
 
-`alertify` allows you to specify a device ID of a Spotify [player] device to play the alert song on via command line parameters. If you leave these empty, `alertify` will scan the local network for all available Spotify devices and play the song on the first [active device](https://beta.developer.spotify.com/documentation/web-api/guides/using-connect-web-api/#viewing-active-device-list). If none is found, `alertify` won't start and will fail with non-zero exit status code.
+`slackertify` allows you to specify a specific Spotify device ID to play a song configured by passing in Spotify Song URI via command line parameters. If you leave these empty, `slackertify` will scan the local network for all available Spotify devices and play a default song on the first [active device](https://beta.developer.spotify.com/documentation/web-api/guides/using-connect-web-api/#viewing-active-device-list). If no active device is found, `slackertify` won't start and will fail straight away with non-zero exit status.
 
 ## API service
 
-`alertify` also provides a simple API service **without any authentication** that also allows you to trigger the playback of a song or pause it. Here is a simple example what this looks like in practice:
-
-Start `alertify`:
-
-```
-[ alertify ] Registering HTTP route -> Method: POST, Path: /alert/play
-[ alertify ] Registering HTTP route -> Method: POST, Path: /alert/silence
-[ alertify ] Starting Slack API message watcher
-[ alertify ] Starting bot command listener
-[ alertify ] Starting HTTP API service
-```
+As discussed earlier, `alertify.Bot` implements a simple HTTP API which allows you to trigger the playback of a song or pause it. Here is a simple example what this looks like in practice:
 
 Trigger the alert playback:
 
@@ -107,13 +168,12 @@ $ curl -X POST localhost:8080/alert/play
 The song should start playing on either the explicitly Spotify device or on the firs available device:
 
 ```
-[ alertify ] Starting HTTP API service
-[ alertify ] POST	/alert/play
-[ alertify ] Received command: alert
-[ alertify ] Attempting to play: Take Me Home, Country Roads on device: xxxxxxxxx - ceres
+[ slackertify ] POST	/alert/play
+[ slackertify ] Received message: alert
+[ slackertify ] Attempting to play: "Take Me Home, Country Roads" on Device ID: f6e2bbe128cd0b9b5137ee18dd5afdc34b6a2598 Name: ceres
 ```
 
-Silence the alert song:
+You can also silence the alert song via the API:
 
 ```
 $ curl -X POST localhost:8080/alert/silence
@@ -122,21 +182,36 @@ $ curl -X POST localhost:8080/alert/silence
 The song should now be paused:
 
 ```
-[ alertify ] POST	/alert/silence
-[ alertify ] Received command: silence
-[ alertify ] Attempting to silence alert  playback on device: xxxxxxxxx - ceres
+[ slackertify ] POST	/alert/silence
+[ slackertify ] Received message: silence
+[ slackertify ] Attempting to pause alert playback on Device ID: f6e2bbe128cd0b9b5137ee18dd5afdc34b6a2598 Name: ceres
 ```
 
 ## Slack messages
 
-By default `alertify` listens to all Slack messages in channel called `devops-production` -- you can change the channel name via `-alert-channel` cli option. `alertify` will play song on Spotify once it detects a message sent by `production` (configurable via `-alert-bot`)  which contains `alert` in the message (configurable via `-alert-msg`).
+`slackertify` listens to all Slack messages in a Slack channel specified via `-slack-channel` command line switch. `slackertify` will play a song once it detects a message sent by a user specified via `-slack-user` command line switch  which has a pattern specified via `-slack-msg` command line switch:
 
-Once `alertify` detects a message that matches regexp passed in to `-alert-msg` cli parameter it will start playing the song:
 
 ```
-[ alertify ] Slack alert detected
-[ alertify ] Received command: alert
-[ alertify ] Attempting to play: Take Me Home, Country Roads on device: xxxxxxxxx - ceres
+[ slackertify ] Slack alert message match detected!
+[ slackertify ] Received message: alert
+```
+
+## Shutting down
+
+`slackertify` implements basic signal handler and stops all goroutines safely:
+
+```
+^C[ slackertify ] Got signal: interrupt: Shutting down
+[ slackertify ] Stopping message listener
+[ slackertify ] HTTP API service shutting down
+[ slackertify ] HTTP API service stopped
+[ slackertify ] Message listener shutting down
+[ slackertify ] Message listener stopped
+[ slackertify ] Shutting down Slack Monitor
+[ slackertify ] Slack Monitor stopped
+[ slackertify ] Slack Monitor stopped
+[ slackertify ] Bot message listener stopped
 ```
 
 # Contributing

--- a/api.go
+++ b/api.go
@@ -1,4 +1,4 @@
-package main
+package alertify
 
 import (
 	"log"

--- a/monitor.go
+++ b/monitor.go
@@ -1,0 +1,11 @@
+package alertify
+
+// Monitor monitors some activity and sends message to channel
+type Monitor interface {
+	// MonitorAndAlert sends messages to message channel
+	MonitorAndAlert(chan<- *Msg) error
+	// Stop stops the monitor
+	Stop()
+	// String implements stringer interface
+	String() string
+}

--- a/server.go
+++ b/server.go
@@ -18,7 +18,7 @@ type API struct {
 
 // Context provides API service context
 type Context struct {
-	cmdChan chan *Msg
+	msgChan chan *Msg
 }
 
 // newListener creates a new TCP listener

--- a/server.go
+++ b/server.go
@@ -1,4 +1,4 @@
-package main
+package alertify
 
 import (
 	"crypto/tls"

--- a/spotify.go
+++ b/spotify.go
@@ -1,4 +1,4 @@
-package main
+package alertify
 
 import (
 	"fmt"
@@ -121,9 +121,12 @@ func NewSpotifyClient(c *SpotifyConfig) (*SpotifyClient, error) {
 	case client = <-clientChan:
 		listener.Close()
 	case err = <-errChan:
-		log.Printf("Error stopping Spotify authenticator: %s", err)
 	}
 	wg.Wait()
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create Spotify client: %s", err)
+	}
 
 	// configure Spotify player device
 	deviceID := spotify.ID(c.DeviceID)
@@ -212,7 +215,7 @@ func (s *SpotifyClient) PlaySong(songURI string) error {
 		}
 	}
 
-	log.Printf("Attempting to play: %s on device: %s - %s", trackName, s.device.ID, s.device.Name)
+	log.Printf("Attempting to play: \"%s\" on Device ID: %s Name: %s", trackName, s.device.ID, s.device.Name)
 
 	return s.PlayOpt(opts)
 }
@@ -224,7 +227,7 @@ func (s *SpotifyClient) Pause() error {
 		DeviceID: &s.device.ID,
 	}
 
-	log.Printf("Attempting to silence alert song playback on device: %s - %s", s.device.ID, s.device.Name)
+	log.Printf("Attempting to pause alert playback on Device ID: %s Name: %s", s.device.ID, s.device.Name)
 
 	return s.PauseOpt(opts)
 }

--- a/spotify.go
+++ b/spotify.go
@@ -188,7 +188,7 @@ func (s *SpotifyClient) SetDevice(deviceID, deviceName string) error {
 func (s *SpotifyClient) PlaySong(songURI string) error {
 	s.Lock()
 	defer s.Unlock()
-	// if empty, play default song: car crash
+	// if empty, play default song
 	if songURI == "" {
 		songURI = "spotify:track:7yTIKQzqRQfXDKKiPw3GJY"
 	}
@@ -224,7 +224,7 @@ func (s *SpotifyClient) Pause() error {
 		DeviceID: &s.device.ID,
 	}
 
-	log.Printf("Attempting to silence alert  playback on device: %s - %s", s.device.ID, s.device.Name)
+	log.Printf("Attempting to silence alert song playback on device: %s - %s", s.device.ID, s.device.Name)
 
 	return s.PauseOpt(opts)
 }


### PR DESCRIPTION
Alertify is now a full fledged Go package

    Turning the project into a package allows to reuse it in other programs.
    It now allows to register various monitoring sources with the main bot
    as long as they implement particular interface.

    Slack parts have been ripped out of the core package and moved to a
    dedicated monitor package.

    The original full program has been moved to examples directory and is
    now called `slackertify`.